### PR TITLE
BF: provide full URLs to github for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tpl-fMRIPrep"]
 	path = tpl-fMRIPrep
-	url = ./tpl-fMRIPrep
+	url = https://github.com/templateflow/tpl-fMRIPrep
 [submodule "tpl-MNI152NLin2009cAsym"]
 	path = tpl-MNI152NLin2009cAsym
-	url = ./tpl-MNI152NLin2009cAsym
+	url = https://github.com/templateflow/tpl-MNI152NLin2009cAsym


### PR DESCRIPTION
Unfortunately ATM DataLad does not do any magic/custom discovery
for sub-dataset URLs whenever they come from "flattened" list
as on GitHub.  So if GitHub is intended to be original source,
you would need to provide full URLs. It should though work ok
even if this hierarchy would get published somewhere as a hierarchy
(e.g. http://datasets.datalad.org) since git itself does first
attempt to clone from "father" git URL + submodule path and only
if fails then goes after url in .gitmodules